### PR TITLE
Escape FFmpeg paths with spaces

### DIFF
--- a/transcoder.go
+++ b/transcoder.go
@@ -206,7 +206,8 @@ func (transcoder Transcoder) ProbeSubtitleFilter(source string) string {
 
 	for _, stream := range ffprobeOutput.Streams {
 		if strings.ToLower(stream.Tags.Language) == "eng" {
-			return fmt.Sprintf("subtitles='%s':si=%d", source, stream.Index)
+			escaped := escapeFFmpegPath(source)
+			return fmt.Sprintf("subtitles=%s:si=%d", escaped, stream.Index)
 		}
 	}
 
@@ -330,6 +331,17 @@ func (handle *TranscoderHandle) readStdOut() {
 			log.Printf("%s: Transcoding... %s", handle.sourceFile, v)
 		}
 	}
+}
+
+func escapeFFmpegPath(path string) string {
+	replacer := strings.NewReplacer(
+		"\\", "\\\\",
+		":", "\\:",
+		"?", "\\?",
+		"'", "\\'",
+		" ", "\\ ",
+	)
+	return replacer.Replace(path)
 }
 
 func splitKeyValue(line string) (string, string) {

--- a/transcoder_test.go
+++ b/transcoder_test.go
@@ -1,0 +1,11 @@
+package main
+
+import "testing"
+
+func TestEscapeFFmpegPath(t *testing.T) {
+	input := "/path/with space/file's.mp4"
+	expected := `/path/with\ space/file\'s.mp4`
+	if got := escapeFFmpegPath(input); got != expected {
+		t.Errorf("escapeFFmpegPath(%q) = %q, want %q", input, got, expected)
+	}
+}


### PR DESCRIPTION
## Summary
- escape ffmpeg paths used in subtitle filter so spaces are handled correctly
- add test verifying path escaping

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689e846d1a0c8322b821ab8d755f4dce