### PR TITLE
Add default YADIF deinterlacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ That's where this very specialized piece of modern software art got you covered:
 You can browse through your files with a mobile-friendly Web-UI (better than the apache/nginx directory index!), access any files that
 your device can natively read and start a ffmpeg-based transcoder process to h264/AAC in HLS for the files it can't read. After only some
 seconds you can start to stream this funny little clip you laughed so hard over when you were a teen to our device. If an English subtitle
-track is present it will be burned into the transcoded output so the subtitles are displayed automatically.
+track is present it will be burned into the transcoded output so the subtitles are displayed automatically. Videos are deinterlaced using ffmpeg's `yadif` filter by default to improve playback quality.
 
 The HLS-Stream is of type *EVENT*, so for compatible Players* it starts as a Live-Stream, that soon becomes navigatable as the
 transcoding continues to convert more and more of the source material. Once the transcoder is done completely, the HLS-Playlist gets

--- a/transcoder.go
+++ b/transcoder.go
@@ -88,8 +88,13 @@ func (transcoder Transcoder) StartTranscoder(sourceFile string, destinationFolde
 		"-analyzeduration", "20000000",
 	}
 
+	filterNone := "yadif"
+	if subtitleFilter != "" {
+		filterNone += "," + subtitleFilter
+	}
 	cmdAccNone := []string{
 		"-threads", "16",
+		"-vf", filterNone,
 		"-c:v:0", "libx264",
 		"-pix_fmt", "yuv420p",
 		"-bufsize", "8192k",
@@ -99,17 +104,14 @@ func (transcoder Transcoder) StartTranscoder(sourceFile string, destinationFolde
 		"-profile", "main",
 		"-level", "4.0",
 	}
-	if subtitleFilter != "" {
-		cmdAccNone = append(cmdAccNone, "-vf", subtitleFilter)
-	}
 
-	filter := "scale=iw*sar:ih,setsar=1:1"
+	filterAccel := "yadif,scale=iw*sar:ih,setsar=1:1"
 	if subtitleFilter != "" {
-		filter = filter + "," + subtitleFilter
+		filterAccel += "," + subtitleFilter
 	}
 	cmdAccH264V4l2m2m := []string{
 		"-threads", "8",
-		"-vf", filter,
+		"-vf", filterAccel,
 		"-c:v:0", "h264_v4l2m2m",
 		"-pix_fmt", "yuv420p",
 		"-bufsize", "8192k",


### PR DESCRIPTION
## Summary
- apply YADIF deinterlacing filter by default for CPU and hardware accelerated transcoding
- mention default deinterlacing in README

## Testing
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_689e866890288322aabb745ce4f6a2fe