### PR TITLE
Handle spaces in HLS filenames

### DIFF
--- a/player_handler.go
+++ b/player_handler.go
@@ -4,6 +4,7 @@ import (
 	"html/template"
 	"log"
 	"net/http"
+	"net/url"
 	"path/filepath"
 )
 
@@ -29,15 +30,16 @@ func (handler *PlayerHandler) Handle(writer http.ResponseWriter, request *http.R
 		case NoStream:
 		case StreamTranscodingFailed:
 		case StreamInPreparation:
-			streamInfoUrl := mappingResult.UrlPath + "?stream"
-			http.Redirect(writer, request, streamInfoUrl, http.StatusSeeOther)
+			RelativeRedirect(writer, request, "?stream", http.StatusSeeOther)
 			return
 		}
 	}
 
 	writer.Header().Add("Content-Type", "text/html; charset=utf-8")
 
-	playbackUrl := mappingResult.UrlPath
+	encodedUrl := (&url.URL{Path: mappingResult.UrlPath}).String()
+
+	playbackUrl := encodedUrl
 	if isStream {
 		playbackUrl += "?stream&playlist"
 	}
@@ -51,7 +53,7 @@ func (handler *PlayerHandler) Handle(writer http.ResponseWriter, request *http.R
 	}{
 		dir,
 		file,
-		mappingResult.UrlPath,
+		encodedUrl,
 		playbackUrl,
 	}); err != nil {
 		log.Printf("Template-Formatting failed: %s", err)

--- a/stream_status_manager.go
+++ b/stream_status_manager.go
@@ -4,6 +4,7 @@ import (
 	"github.com/gosimple/slug"
 	"io/ioutil"
 	"log"
+	"net/url"
 	"os"
 	"sync"
 	"time"
@@ -33,6 +34,7 @@ func NewStreamStatusManager(tempDir string, transcoder Transcoder) StreamStatusM
 type StreamInfo struct {
 	CalculatedPath string
 	UrlPath        string
+	EncodedUrlPath string
 	TempDir        string
 	handle         *TranscoderHandle
 	LastAccess     time.Time
@@ -121,12 +123,15 @@ func (manager *StreamStatusManager) StartStream(calculatedPath string, urlPath s
 	log.Printf("%s: Starting Stream-Transcoder into %s", calculatedPath, tempDir)
 	handle := manager.transcoder.StartTranscoder(calculatedPath, tempDir)
 
+	encodedUrl := (&url.URL{Path: urlPath}).String()
+
 	manager.streamInfo[calculatedPath] = StreamInfo{
-		calculatedPath,
-		urlPath,
-		tempDir,
-		handle,
-		time.Now(),
+		CalculatedPath: calculatedPath,
+		UrlPath:        urlPath,
+		EncodedUrlPath: encodedUrl,
+		TempDir:        tempDir,
+		handle:         handle,
+		LastAccess:     time.Now(),
 	}
 }
 

--- a/templates/directory-index.gohtml
+++ b/templates/directory-index.gohtml
@@ -14,52 +14,52 @@
 	<input type="text" class="form-control" id="search" placeholder="Filter…">
 	<ul class="list-group mt-3" id="filter-list">
         {{range .Files}}
-			<li class="list-group-item" data-url="{{.Url}}">
-				<div class="row">
+                        <li class="list-group-item" data-url="{{.Url}}">
+                                <div class="row">
                     {{if .IsDir}}
-						<div class="col-12 text-truncate">
-							<a href="{{.Name}}/">
-								<i class="far fa-folder mr-1"></i>
+                                                <div class="col-12 text-truncate">
+                                                        <a href="{{.EncodedName}}/">
+                                                                <i class="far fa-folder mr-1"></i>
                                 {{.Name}}
-							</a>
-						</div>
+                                                        </a>
+                                                </div>
                     {{else if or .CanStream .CanPlay}}
-						<div class="col-md-8 text-truncate">
-							{{if .CanStream}}
-							<a href="{{.Name}}?stream">
-								<i class="far fa-file-video mr-1"></i>
-								{{.Name}}
-								<em>(Stream)</em>
-							</a>
-							{{else if .CanPlay}}
-							<a href="{{.Name}}?play">
-								<i class="far fa-file-video mr-1"></i>
-								{{.Name}}
-								<em>(Play)</em>
-							</a>
-							{{end}}
-						</div>
-						<div class="col-md-4 text-right">
-							<i>{{.Size}}</i>
-							<a href="{{.Name}}" class="font-italic">
-								Download
-								<i class="fas fa-download"></i>
-							</a>
-						</div>
+                                                <div class="col-md-8 text-truncate">
+                                                        {{if .CanStream}}
+                                                        <a href="{{.EncodedName}}?stream">
+                                                                <i class="far fa-file-video mr-1"></i>
+                                                                {{.Name}}
+                                                                <em>(Stream)</em>
+                                                        </a>
+                                                        {{else if .CanPlay}}
+                                                        <a href="{{.EncodedName}}?play">
+                                                                <i class="far fa-file-video mr-1"></i>
+                                                                {{.Name}}
+                                                                <em>(Play)</em>
+                                                        </a>
+                                                        {{end}}
+                                                </div>
+                                                <div class="col-md-4 text-right">
+                                                        <i>{{.Size}}</i>
+                                                        <a href="{{.EncodedName}}" class="font-italic">
+                                                                Download
+                                                                <i class="fas fa-download"></i>
+                                                        </a>
+                                                </div>
                     {{else}}
-						<div class="col-md-8 text-truncate">
-							<a href="{{.Name}}">
-								<i class="far fa-file mr-1"></i>
+                                                <div class="col-md-8 text-truncate">
+                                                        <a href="{{.EncodedName}}">
+                                                                <i class="far fa-file mr-1"></i>
                                 {{.Name}}
-							</a>
-						</div>
-						<div class="col-md-4 text-right">
-							<i>{{.Size}}</i>
-						</div>
+                                                        </a>
+                                                </div>
+                                                <div class="col-md-4 text-right">
+                                                        <i>{{.Size}}</i>
+                                                </div>
                     {{end}}
-				</div>
-				<div class="playback-progress"></div>
-			</li>
+                                </div>
+                                <div class="playback-progress"></div>
+                        </li>
         {{end}}
 	</ul>
 {{end}}

--- a/templates/status-page.gohtml
+++ b/templates/status-page.gohtml
@@ -148,9 +148,9 @@
 
 				<ul class="mt-3">
                     {{range .OtherRunningTranscoders}}
-						<li>
-							<a href="{{.UrlPath}}?stream">{{.UrlPath}}</a>
-						</li>
+                                                <li>
+                                                        <a href="{{.EncodedUrlPath}}?stream">{{.UrlPath}}</a>
+                                                </li>
                     {{end}}
 				</ul>
 			</div>


### PR DESCRIPTION
## Summary
- Encode file and playlist paths so spaces and special characters are handled safely
- Track encoded URLs in stream status for cross-page links
- Replace raw redirects and links with encoded versions throughout the UI

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689e864f6f948322b03e322ebeed8824